### PR TITLE
Add GCP template for container optimized OS VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains all currently available templates which you can use to deploy
 
 - [Azure](azure/)
 - [AWS](aws/)
-- GCE (coming soon)
+- [GCP](gcp/)
 
 All the templates require the followings:
 - Bring your own license. You can get a license [here](https://www.landoop.com/downloads/)

--- a/gcp/common/container_helper.jinja
+++ b/gcp/common/container_helper.jinja
@@ -1,0 +1,57 @@
+{% set COMPUTE_URL_BASE = 'https://www.googleapis.com/compute/v1/' %}
+
+{% macro GlobalComputeUrl(project, collection, name) -%}
+{{ COMPUTE_URL_BASE }}projects/{{ project }}/global/{{ collection }}/{{ name }}
+{%- endmacro %}
+
+{% macro ZonalComputeUrl(project, zone, collection, name) -%}
+{{ COMPUTE_URL_BASE }}projects/{{ project }}/zones/{{ zone }}/{{ collection }}/{{ name }}
+{%- endmacro %}
+
+{% macro GenerateManifest(name, port, dockerImage, dockerEnv, lensesLicense, lensesSecurityUsers, lensesSecurityGroups) -%}
+
+{# Generates a Container Manifest given a Template context.
+   Args:
+     context: Template context, which must contain dockerImage and port
+        properties, and an optional dockerEnv property.
+   Returns:
+     A Container Manifest as a YAML string.
+-#}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: "{{ name }}"
+  app:  "{{ name }}"
+  component: {{ name }}
+  lenses.io/app:  "{{ name }}"
+  lenses.io/app.type: "lenses"
+spec:
+  volumes:
+    - name: {{name}}-volume
+      gcePersistentDisk:
+        pdName: {{name}}-data-disk
+        fsType: ext4
+  containers:
+  - name: {{ name }}
+    image: {{ dockerImage }}
+    imagePullPolicy: Always
+    ports:
+    - hostPort: {{ port }}
+      containerPort: {{ port }}
+    {% if dockerEnv -%}
+    env:
+    {% for key, value in dockerEnv.iteritems() -%}
+    - name: {{ key }}
+      value: '{{ value }}'
+    {% endfor -%}
+    {% endif -%}
+    - name: LICENSE
+      value: '{{ lensesLicense | indent(4) }}'
+    - name: LENSES_SECURITY_GROUPS
+      value: '{{ lensesSecurityGroups | indent(4) }}'
+    - name: LENSES_SECURITY_USERS
+      value: '{{ lensesSecurityUsers | indent(4) }}'
+    volumeMounts:
+    - name: {{name}}-volume
+      mountPath: /data/storage
+{%- endmacro -%}

--- a/gcp/common/container_instance_template.jinja
+++ b/gcp/common/container_instance_template.jinja
@@ -1,0 +1,52 @@
+{% from 'container_helper.jinja' import GenerateManifest,GlobalComputeUrl,ZonalComputeUrl %}
+
+{% set VM_NAME = env['name'] + '-vm' %}
+
+resources:
+- name: {{ env['name'] }}-data-disk
+  type: compute.v1.disk
+  properties:
+    zone: {{ properties['zone'] }}
+    sizeGb: {{ properties['diskSizeGB'] }}
+    type: {{ ZonalComputeUrl(env['project'], properties['zone'], 'diskTypes', properties['diskType']) }}
+
+- name: {{ VM_NAME }}
+  type: compute.v1.instance
+  properties:
+    metadata:
+      items:
+      - key: gce-container-declaration
+        value: |
+          {{ GenerateManifest(env['name'], properties['port'], properties['dockerImage'], properties['dockerEnv'], properties['lensesLicense'], properties['lensesSecurityUsers'], properties['lensesSecurityGroups']) | indent(10) }}
+    zone: {{ properties['zone'] }}
+    machineType: {{ ZonalComputeUrl(env['project'], properties['zone'], 'machineTypes', properties['machineType']) }}
+    disks:
+    - deviceName: boot
+      boot: true
+      autoDelete: true
+      mode: READ_WRITE
+      type: PERSISTENT
+      initializeParams:
+        sourceImage: {{ GlobalComputeUrl('cos-cloud', 'images', properties['containerImage']) }}
+    - deviceName: {{ env['name'] }}-data-disk
+      boot: false
+      autoDelete: false
+      mode: READ_WRITE
+      type: PERSISTENT
+      source: $(ref.{{ env['name'] }}-data-disk.selfLink)
+    networkInterfaces:
+    - accessConfigs:
+      - name: external-nat
+        type: ONE_TO_ONE_NAT
+      network: {{ GlobalComputeUrl(env['project'], 'networks', properties['network']) }}
+    serviceAccounts:
+      - email: default
+        scopes:
+        - https://www.googleapis.com/auth/logging.write
+        - https://www.googleapis.com/auth/monitoring.write
+    tags:
+        items: ["{{ env['name'] }}-http"]
+
+outputs:
+- name: instanceTemplateSelfLink
+  value: $(ref.{{ VM_NAME }}.selfLink)

--- a/gcp/common/container_instance_template.jinja.schema
+++ b/gcp/common/container_instance_template.jinja.schema
@@ -1,0 +1,71 @@
+info:
+  title: Container Instance Template
+  author: Google
+  description: Create container instance templates
+  version: 1.0
+
+imports:
+- path: container_helper.jinja
+
+required:
+- port
+- dockerImage
+- containerImage
+- lensesLicense
+- lensesSecurityUsers
+- lensesSecurityGroups
+
+properties:
+  lensesLicense:
+    type: string
+    description: The Lenses.io License
+  
+  lensesSecurityUsers:
+    type: string
+    description: The Lenses.io License
+  
+  lensesSecurityGroups:
+    type: string
+    description: The Lenses.io License
+  
+  zone:
+    type: string
+    description: The zone which Lenses.io will run
+    default: europe-west3-a
+
+  port:
+    type: integer
+    description: The host port and container port
+
+  dockerImage:
+    type: string
+    description: The docker image to be used
+
+  dockerEnv:
+    type: object
+    description: The container environment variables
+    default: {}
+
+  containerImage:
+    type: string
+    description: The container image to be used
+
+  network:
+    type: string
+    description: The network to deploy Lenses.io
+
+  diskSizeGB:
+    type: integer
+    default: 20
+
+  diskType:
+    type: string
+    default: pd-standard
+    enum:
+    - pd-standard
+    - pd-ssd
+
+outputs:
+  instanceTemplateSelfLink:
+    type: string
+    description: The selflink of this instance template

--- a/gcp/container-vm/README.md
+++ b/gcp/container-vm/README.md
@@ -1,0 +1,16 @@
+# Deployment of Lenses in Container Optimized OS
+
+This is a
+[Google Cloud Deployment Manager](https://cloud.google.com/deployment-manager/overview)
+template that deploys Lenses in a Container Optimized OS VM.
+
+## Deploy the template
+
+Use `config.yaml` to deploy Lenses template. This template uses
+Container Optimized OS VM and creates by itslef the necessary Firewall configuration.
+
+When ready, deploy with the following command:
+
+```shell
+gcloud deployment-manager deployments create lenses --config config.yaml
+```

--- a/gcp/container-vm/config.yaml
+++ b/gcp/container-vm/config.yaml
@@ -1,0 +1,14 @@
+imports:
+- path: lenses.jinja
+
+resources:
+- name: lenses2
+  type: lenses.jinja
+  properties:
+    zone: europe-west3-a
+    sourceRanges: "0.0.0.0/0"
+    kafkaBrokers: 
+    lensesLicense: |
+    zookeeper: |
+    schemaRegistry: |
+    connect: |

--- a/gcp/container-vm/lenses.jinja
+++ b/gcp/container-vm/lenses.jinja
@@ -1,0 +1,52 @@
+resources:
+
+- name: {{ env['name'] }}-firewall
+  type: compute.v1.firewall
+  properties:
+    allowed:
+      - IPProtocol: TCP
+        ports: [ {{ properties['lensesPort'] }} ]
+    sourceRanges: [ "{{ properties['sourceRanges'] }}" ]
+    targetTags: ["{{ env['name'] }}-http"]
+
+- name: {{ env["name"] }}
+  type: container_instance_template.jinja
+  properties:
+    zone: {{ properties['zone'] }}
+    dockerImage: landoop/lenses:2.3
+    containerImage: family/cos-stable
+    port: {{ properties['lensesPort'] }}
+    network: {{ properties['network'] }}
+    machineType: {{ properties['machineType'] }}
+    lensesLicense: '{{ properties["lensesLicense"] }}'
+    lensesSecurityGroups: |
+        [
+          {"name": "adminGroup", "roles": ["Admin", "DataPolicyWrite", "AlertsWrite", "TableStorageWrite"]},
+          {"name": "readGroup",  "roles": ["Read"]}
+        ]      
+    lensesSecurityUsers: |
+        [
+          {"username": "admin", "password": "{{ properties['lensesPassword'] }}", "displayname": "Lenses Admin", "groups": ["adminGroup"]},
+          {"username": "read", "password": "read", "displayname": "Read Only", "groups": ["readGroup"]}
+        ]
+    
+    dockerEnv:
+      LENSES_PORT: {{ properties['lensesPort'] }}
+      LENSES_SECURITY_MODE: BASIC
+      LENSES_KAFKA_BROKERS: '{{ properties['kafkaBrokers'] }}'
+      LENSES_ZOOKEEPER_HOSTS: '{{ properties['zookeeper'] }}'
+      LENSES_SCHEMA_REGISTRY_URLS: '{{ properties['schemaRegistry'] }}'
+      LENSES_CONNECT_CLUSTERS: '{{ properties['connect'] }}'
+
+      SD_CONFIG: provider=gce zone_pattern={{ properties['zone'] }}.*
+      SD_BROKER_FILTER: tag_value=broker
+      SD_ZOOKEEPER_FILTER: tag_value=zookeeper
+      SD_ZOOKEEPER_JMX_PORT: 9585
+      SD_REGISTRY_FILTER: tag_value=schema-registry
+      SD_REGISTRY_JMX_PORT: 9582
+      SD_CONNECT_FILTERS: tag_value=connect-worker-testing,tag_value=connect-worker-production
+      SD_CONNECT_NAMES: testing,production
+      SD_CONNECT_STATUSES: connect-statuses-testing,connect-statuses-production
+      SD_CONNECT_CONFIGS: connect-configs-testing,connect-configs-production
+      SD_CONNECT_OFFSETS: connect-offsets-testing,connect-offsets-production
+      SD_CONNECT_JMX_PORTS: 9584

--- a/gcp/container-vm/lenses.jinja.schema
+++ b/gcp/container-vm/lenses.jinja.schema
@@ -1,0 +1,67 @@
+info:
+  title: VM Template
+  author: Lenses.io
+  description: Creates a instance
+  version: 1.0
+
+imports:
+- path: ../common/container_instance_template.jinja
+  name: container_instance_template.jinja
+
+required:
+- zone
+- machineType
+- sourceRanges
+- kafkaBrokers
+- lensesLicense
+
+properties:
+  zone:
+    type: string
+    description: Zone where the instance resides
+    default: europe-west3-a
+  
+  machineType:
+    type: string
+    description: The type of the machine which lenses run. Recommended >= n1-standard-2
+    default: n1-standard-2
+  
+  network:
+    type: string
+    description: The network in which Lenses.io will be deployed
+    default: default
+
+  sourceRanges:
+    type: string
+    description: Source ranges for Firewall configuration
+    default: 0.0.0.0/0
+
+  lensesPort:
+    type: integer
+    description: The port which Lenses.io will run
+    default: 9991
+  
+  lensesLicense:
+    type: string
+    description: The Lenses.io License
+  
+  lensesPassword:
+    type: string
+    description: The password which will be used for Lenses.io to login
+    default: admin
+
+  kafkaBrokers:
+    type: string
+    description: The kafka connections string.
+
+  zookeeper:
+    type: string
+    description: The Zookeeper connection string (JSON)
+
+  schemaRegistry:
+    type: string
+    description: The Schema Registry connection string (JSON)
+
+  connect:
+    type: string
+    description: The Connect connection string (JSON)


### PR DESCRIPTION
- Creates a VM instance
- Utilizes `gce-container-declaration` metadata for container
- Generates its own firewall settings based on the configuration